### PR TITLE
fix: fix non-linux release builds 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [ "published" ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "fix-multi-arch-build" ]
   pull_request:
     branches: [ "main" ]
 
@@ -29,11 +29,6 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Build
-      run: |
-        VERSION="$(git describe --tags --always)"
-        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
-
     - name: Test
       run: go test -v ./...
 
@@ -48,6 +43,7 @@ jobs:
     - name: Package
       run: |
         VERSION="$(git describe --tags --always)"
+        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
         DIR="$(mktemp -d)"
         mkdir "$DIR/age-plugin-sss"
         cp LICENSE "$DIR/age-plugin-sss"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,11 +60,12 @@ jobs:
       if: matrix.GOOS == 'linux' && matrix.GOARCH == 'amd64'
       run: |
         export GOBIN="$HOME/.local/bin/"
+        go build -v ./cmd/...
         go install github.com/rogpeppe/go-internal/cmd/testscript@v1.12.0
         go install filippo.io/age/cmd/...@latest
-        tree .
-        cp age-plugin-sss/age-plugin-sss "$HOME/.local/bin/age-plugin-sss"
+        cp age-plugin-sss "$HOME/.local/bin/age-plugin-sss"
         testscript ./testdata/*.txt
+        rm age-plugin-sss
 
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,6 +62,7 @@ jobs:
         export GOBIN="$HOME/.local/bin/"
         go install github.com/rogpeppe/go-internal/cmd/testscript@v1.12.0
         go install filippo.io/age/cmd/...@latest
+        tree .
         cp age-plugin-sss/age-plugin-sss "$HOME/.local/bin/age-plugin-sss"
         testscript ./testdata/*.txt
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [ "published" ]
   push:
-    branches: [ "main", "fix-multi-arch-build" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   GO_VERSION: '>=1.21'
-  CGO_ENABLED: 1
+  CGO_ENABLED: 0
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
           - {GOOS: linux, GOARCH: arm64}
           - {GOOS: darwin, GOARCH: amd64}
           - {GOOS: darwin, GOARCH: arm64}
-          - {GOOS: windows, GOARCH: amd64}
+          # - {GOOS: windows, GOARCH: amd64} TODO: figure out how to fix build
           - {GOOS: freebsd, GOARCH: amd64}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,7 +62,7 @@ jobs:
         export GOBIN="$HOME/.local/bin/"
         go install github.com/rogpeppe/go-internal/cmd/testscript@v1.12.0
         go install filippo.io/age/cmd/...@latest
-        cp age-plugin-sss "$HOME/.local/bin/age-plugin-sss"
+        cp age-plugin-sss/age-plugin-sss "$HOME/.local/bin/age-plugin-sss"
         testscript ./testdata/*.txt
 
     - name: Upload workflow artifacts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,14 +32,6 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-    - name: Test E2E
-      run: |
-        export GOBIN="$HOME/.local/bin/"
-        go install github.com/rogpeppe/go-internal/cmd/testscript@v1.12.0
-        go install filippo.io/age/cmd/...@latest
-        cp age-plugin-sss "$HOME/.local/bin/age-plugin-sss"
-        testscript ./testdata/*.txt
-
     - name: Package
       run: |
         VERSION="$(git describe --tags --always)"
@@ -58,6 +50,15 @@ jobs:
         GOOS: ${{ matrix.GOOS }}
         GOARCH: ${{ matrix.GOARCH }}
         GOARM: ${{ matrix.GOARM }}
+
+    - name: Test E2E
+      if: env.GOOS == 'linux' && env.GOARCH == 'amd64'
+      run: |
+        export GOBIN="$HOME/.local/bin/"
+        go install github.com/rogpeppe/go-internal/cmd/testscript@v1.12.0
+        go install filippo.io/age/cmd/...@latest
+        cp age-plugin-sss "$HOME/.local/bin/age-plugin-sss"
+        testscript ./testdata/*.txt
 
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
         GOARM: ${{ matrix.GOARM }}
 
     - name: Test E2E
-      if: env.GOOS == 'linux' && env.GOARCH == 'amd64'
+      if: matrix.GOOS == 'linux' && matrix.GOARCH == 'amd64'
       run: |
         export GOBIN="$HOME/.local/bin/"
         go install github.com/rogpeppe/go-internal/cmd/testscript@v1.12.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  GO_VERSION: '>=1.21'
+  CGO_ENABLED: 1
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Test
       run: go test -v ./...
@@ -47,6 +51,7 @@ jobs:
           tar -cvzf "age-plugin-sss-$VERSION-$GOOS-$GOARCH.tar.gz" -C "$DIR" age-plugin-sss
         fi
       env:
+        CGO_ENABLED: ${{ env.CGO_ENABLED }}
         GOOS: ${{ matrix.GOOS }}
         GOARCH: ${{ matrix.GOARCH }}
         GOARM: ${{ matrix.GOARM }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,21 @@
 
 ### Download/Install Binary
 
-Go to the [release page](https://github.com/olastor/age-plugin-sss/releases/) and download the correct binary for your architecture. Unpack it and move it to a directory in your `$PATH`.
+Download a the latest binary from the [release page](https://github.com/olastor/age-plugin-sss/releases). Copy the binary to your `$PATH` (preferably in `$(which age)`) and make sure it's executable.
+
+You can also use the following script for installation:
+
+- Installs binary to `~/.local/bin/age-plugin-sss` (change to your preferred directory)
+- Make sure to adjust `OS` and `ARCH` if needed (`OS=darwin ARCH=arm64` for Apple Silicon, `OS=darwin ARCH=amd64` for older Macs)
+
+```bash
+cd "$(mktemp -d)"
+VERSION=v0.2.4 OS=linux ARCH=amd64; curl -L "https://github.com/olastor/age-plugin-sss/releases/download/$VERSION/age-plugin-sss-$VERSION-$OS-$ARCH.tar.gz" -o age-plugin-sss.tar.gz
+tar -xzf age-plugin-sss.tar.gz
+mv age-plugin-sss/age-plugin-sss ~/.local/bin
+```
+
+Please note that Windows builds are currently not enabled, but if you need them please open a new issue and I'll try to look into it.
 
 ### Build from source
 


### PR DESCRIPTION
- fix builds not using GOOS / GOARCH env variables
- set `CGO_ENABLED: 0`
- disable windows build (because it's throwing an error)