### PR TITLE
Add support for plugin decryption of mlkem768x25519 stanzas

### DIFF
--- a/pkg/sss/policy.go
+++ b/pkg/sss/policy.go
@@ -3,6 +3,7 @@ package sss
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"filippo.io/age"
@@ -31,7 +32,7 @@ func (policy *SSS) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (policy *SSS) Wrap(fileKey []byte) (stanza []*age.Stanza, err error) {
-	sssStanza, err := policy.wrap(fileKey)
+	sssStanza, _, err := policy.wrap(fileKey)
 	if err != nil {
 		return nil, err
 	}
@@ -49,13 +50,32 @@ func (policy *SSS) Wrap(fileKey []byte) (stanza []*age.Stanza, err error) {
 	}, nil
 }
 
-func (policy *SSS) wrap(fileKey []byte) (stanza *SSSStanza, err error) {
+func (policy *SSS) WrapWithLabels(fileKey []byte) ([]*age.Stanza, []string, error) {
+	sssStanza, isPQ, err := policy.wrap(fileKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stanzaBody, err := sssStanza.Marshal()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var labels []string
+	if isPQ {
+		labels = []string{"postquantum"}
+	}
+
+	return []*age.Stanza{{Type: "sss", Body: stanzaBody}}, labels, nil
+}
+
+func (policy *SSS) wrap(fileKey []byte) (stanza *SSSStanza, isPQ bool, err error) {
 	stanza = &SSSStanza{}
 	stanza.Version = 1
 
 	if policy.Shares != nil {
 		if policy.Threshold <= 0 {
-			return nil, errors.New("invalid threshold")
+			return nil, false, errors.New("invalid threshold")
 		}
 
 		var fileKeyShares [][]byte
@@ -70,12 +90,13 @@ func (policy *SSS) wrap(fileKey []byte) (stanza *SSSStanza, err error) {
 		} else {
 			fileKeyShares, err = shamir.Split(fileKey, len(policy.Shares), policy.Threshold)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 		}
 
 		stanza.Threshold = policy.Threshold
 
+		nonPQCount := 0
 		for i, fileKeyShare := range fileKeyShares {
 			// The implementation of SSS creates shares that are one byte larger than the
 			// original secret, but we need the file key share to be exactly the same size
@@ -87,9 +108,13 @@ func (policy *SSS) wrap(fileKey []byte) (stanza *SSSStanza, err error) {
 				shareWithoutX[i] = fileKeyShare[i]
 			}
 
-			subStanza, err := policy.Shares[i].wrap(shareWithoutX)
+			subStanza, subIsPQ, err := policy.Shares[i].wrap(shareWithoutX)
 			if err != nil {
-				return nil, err
+				return nil, false, err
+			}
+
+			if !subIsPQ {
+				nonPQCount++
 			}
 
 			if policy.Threshold > 1 {
@@ -99,11 +124,15 @@ func (policy *SSS) wrap(fileKey []byte) (stanza *SSSStanza, err error) {
 			stanza.Shares = append(stanza.Shares, subStanza)
 		}
 
+		// The SSS group is PQ if a quantum attacker can't reconstruct the secret:
+		// they'd need `threshold` shares, but can only break `nonPQCount` of them.
+		isPQ = nonPQCount < policy.Threshold
+
 		return
 	}
 
 	if policy.Recipient == "" {
-		return nil, errors.New("missing recipient in policy")
+		return nil, false, errors.New("missing recipient in policy")
 	}
 
 	policy.Recipient = strings.TrimSpace(policy.Recipient)
@@ -113,80 +142,88 @@ func (policy *SSS) wrap(fileKey []byte) (stanza *SSSStanza, err error) {
 	switch {
 	case strings.HasPrefix(policy.Recipient, "password-"):
 		if policy.Recipient == "password-" {
-			return nil, errors.New("missing identifier for password")
+			return nil, false, errors.New("missing identifier for password")
 		}
 
 		passwordId := policy.Recipient[9:]
 		password, err := policy.Plugin.RequestValue(fmt.Sprintf("Please enter password \"%s\":", passwordId), true)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		password2, err := policy.Plugin.RequestValue(fmt.Sprintf("Please confirm password \"%s\":", passwordId), true)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		if password != password2 {
-			return nil, errors.New("passwords do not match")
+			return nil, false, errors.New("passwords do not match")
 		}
 
 		scriptRecipient, err := age.NewScryptRecipient(password)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		wrappedShare, err = scriptRecipient.Wrap(fileKey)
 
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	case strings.HasPrefix(policy.Recipient, "age1pq1"):
 		hybridRecipient, err := age.ParseHybridRecipient(policy.Recipient)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
-		wrappedShare, err = hybridRecipient.Wrap(fileKey)
+		wrappedShare, labels, err := hybridRecipient.WrapWithLabels(fileKey)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+
+		isPQ = slices.Contains(labels, "postquantum")
+		stanza.Stanza = wrappedShare
+		return stanza, isPQ, nil
 	case strings.HasPrefix(policy.Recipient, "age1") && strings.Count(policy.Recipient, "1") > 1:
 		pluginRecipient, err := plugin.NewRecipient(policy.Recipient, getPluginClientUIProxy(policy.Plugin))
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
-		wrappedShare, err = pluginRecipient.Wrap(fileKey)
+		wrappedShare, labels, err := pluginRecipient.WrapWithLabels(fileKey)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+
+		isPQ = slices.Contains(labels, "postquantum")
+		stanza.Stanza = wrappedShare
+		return stanza, isPQ, nil
 	case strings.HasPrefix(policy.Recipient, "age1"):
 		x25519Recipient, err := age.ParseX25519Recipient(policy.Recipient)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		wrappedShare, err = x25519Recipient.Wrap(fileKey)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	case strings.HasPrefix(policy.Recipient, "ssh-"):
 		sshRecipient, err := agessh.ParseRecipient(policy.Recipient)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		wrappedShare, err = sshRecipient.Wrap(fileKey)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	default:
-		return nil, fmt.Errorf("unsupported recipient %s", policy.Recipient)
+		return nil, false, fmt.Errorf("unsupported recipient %s", policy.Recipient)
 	}
 
 	if wrappedShare == nil {
-		return nil, fmt.Errorf("could not encrypt to recipient %s", policy.Recipient)
+		return nil, false, fmt.Errorf("could not encrypt to recipient %s", policy.Recipient)
 	}
 
 	stanza.Stanza = wrappedShare

--- a/pkg/sss/policy.go
+++ b/pkg/sss/policy.go
@@ -170,6 +170,10 @@ func (policy *SSS) wrap(fileKey []byte) (stanza *SSSStanza, isPQ bool, err error
 		if err != nil {
 			return nil, false, err
 		}
+
+		// scrypt's primitives (memory-hard KDF + ChaCha20-Poly1305) resist Grover;
+		// password strength is a classical concern, orthogonal to PQ.
+		isPQ = true
 	case strings.HasPrefix(policy.Recipient, "age1pq1"):
 		hybridRecipient, err := age.ParseHybridRecipient(policy.Recipient)
 		if err != nil {

--- a/pkg/sss/policy_test.go
+++ b/pkg/sss/policy_test.go
@@ -354,17 +354,24 @@ func TestWrapWithLabels_Nested(t *testing.T) {
 
 func TestWrapWithLabels_NestedNotPQ(t *testing.T) {
 	// Outer: 1-of-2
-	//   Share 1: PQ recipient
-	//   Share 2: classic recipient
+	//   Share 1: inner 2-of-2 with 2 PQ recipients (PQ group)
+	//   Share 2: classic recipient (leaf)
 	// Outer: nonPQ=1 >= threshold=1 → not PQ
 
-	pqId, _ := age.GenerateHybridIdentity()
+	pq1, _ := age.GenerateHybridIdentity()
+	pq2, _ := age.GenerateHybridIdentity()
 	classicId, _ := age.GenerateX25519Identity()
 
 	policy := &SSS{
 		Threshold: 1,
 		Shares: []*SSS{
-			{Recipient: pqId.Recipient().String()},
+			{
+				Threshold: 2,
+				Shares: []*SSS{
+					{Recipient: pq1.Recipient().String()},
+					{Recipient: pq2.Recipient().String()},
+				},
+			},
 			{Recipient: classicId.Recipient().String()},
 		},
 	}
@@ -377,7 +384,7 @@ func TestWrapWithLabels_NestedNotPQ(t *testing.T) {
 		t.Fatalf("WrapWithLabels: %v", err)
 	}
 	if slices.Contains(labels, "postquantum") {
-		t.Error("1-of-2 with 1 classic share should not be PQ")
+		t.Error("1-of-2 with PQ group + classic leaf: nonPQ(1) >= threshold(1), should not be PQ")
 	}
 }
 

--- a/pkg/sss/policy_test.go
+++ b/pkg/sss/policy_test.go
@@ -4,6 +4,7 @@ import (
 	cryptoRand "crypto/rand"
 	"math/rand"
 	"reflect"
+	"slices"
 
 	"filippo.io/age"
 
@@ -14,6 +15,13 @@ type TestPolicy struct {
 	Threshold int
 	Shares    []*TestPolicy
 	Identity  *age.X25519Identity
+}
+
+// testRecipientInfo holds both classic and PQ recipient/identity for a leaf share
+type testRecipientInfo struct {
+	x25519Identity *age.X25519Identity
+	hybridIdentity *age.HybridIdentity
+	isPQ           bool
 }
 
 func testPolicyToRealPolicy(testPolicy *TestPolicy) *SSS {
@@ -170,4 +178,333 @@ func FuzzRandomPolicies(f *testing.F) {
 			t.Error("File keys should not match")
 		}
 	})
+}
+
+// makeRecipients generates n recipient infos, with the given indices being PQ.
+func makeRecipients(t *testing.T, n int, pqIndices []int) []testRecipientInfo {
+	t.Helper()
+	recipients := make([]testRecipientInfo, n)
+	for i := 0; i < n; i++ {
+		isPQ := slices.Contains(pqIndices, i)
+		if isPQ {
+			id, err := age.GenerateHybridIdentity()
+			if err != nil {
+				t.Fatalf("GenerateHybridIdentity: %v", err)
+			}
+			recipients[i] = testRecipientInfo{hybridIdentity: id, isPQ: true}
+		} else {
+			id, err := age.GenerateX25519Identity()
+			if err != nil {
+				t.Fatalf("GenerateX25519Identity: %v", err)
+			}
+			recipients[i] = testRecipientInfo{x25519Identity: id, isPQ: false}
+		}
+	}
+	return recipients
+}
+
+func recipientString(r testRecipientInfo) string {
+	if r.isPQ {
+		return r.hybridIdentity.Recipient().String()
+	}
+	return r.x25519Identity.Recipient().String()
+}
+
+func buildFlatPolicy(threshold int, recipients []testRecipientInfo) *SSS {
+	policy := &SSS{Threshold: threshold}
+	for _, r := range recipients {
+		policy.Shares = append(policy.Shares, &SSS{Recipient: recipientString(r)})
+	}
+	return policy
+}
+
+func TestWrapWithLabels_AllClassic(t *testing.T) {
+	recipients := makeRecipients(t, 3, nil)
+	policy := buildFlatPolicy(2, recipients)
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if slices.Contains(labels, "postquantum") {
+		t.Error("all-classic policy should not have postquantum label")
+	}
+}
+
+func TestWrapWithLabels_AllPQ(t *testing.T) {
+	recipients := makeRecipients(t, 3, []int{0, 1, 2})
+	policy := buildFlatPolicy(2, recipients)
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if !slices.Contains(labels, "postquantum") {
+		t.Error("all-PQ policy should have postquantum label")
+	}
+}
+
+func TestWrapWithLabels_MixedBelowThreshold(t *testing.T) {
+	// 2-of-3 with 2 PQ and 1 classic: nonPQ=1 < threshold=2 → PQ
+	recipients := makeRecipients(t, 3, []int{0, 1})
+	policy := buildFlatPolicy(2, recipients)
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if !slices.Contains(labels, "postquantum") {
+		t.Error("2-of-3 with 2 PQ shares: nonPQ(1) < threshold(2), should be PQ")
+	}
+}
+
+func TestWrapWithLabels_MixedAtThreshold(t *testing.T) {
+	// 2-of-3 with 1 PQ and 2 classic: nonPQ=2 >= threshold=2 → not PQ
+	recipients := makeRecipients(t, 3, []int{0})
+	policy := buildFlatPolicy(2, recipients)
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if slices.Contains(labels, "postquantum") {
+		t.Error("2-of-3 with 1 PQ share: nonPQ(2) >= threshold(2), should not be PQ")
+	}
+}
+
+func TestWrapWithLabels_ThresholdOne(t *testing.T) {
+	// 1-of-3: any single share can decrypt, so even one classic share breaks PQ.
+	// Only PQ if ALL shares are PQ.
+
+	// Mixed: not PQ
+	recipients := makeRecipients(t, 3, []int{0, 1})
+	policy := buildFlatPolicy(1, recipients)
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if slices.Contains(labels, "postquantum") {
+		t.Error("1-of-3 with any classic share should not be PQ")
+	}
+
+	// All PQ: is PQ
+	recipients2 := makeRecipients(t, 3, []int{0, 1, 2})
+	policy2 := buildFlatPolicy(1, recipients2)
+
+	_, labels2, err := policy2.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if !slices.Contains(labels2, "postquantum") {
+		t.Error("1-of-3 all PQ should be PQ")
+	}
+}
+
+func TestWrapWithLabels_Nested(t *testing.T) {
+	// Outer: 2-of-2
+	//   Share 1: PQ recipient (leaf)
+	//   Share 2: inner 1-of-2 with 2 classic recipients (not PQ)
+	// Outer: nonPQ=1 (the inner group) < threshold=2 → PQ
+
+	pqId, _ := age.GenerateHybridIdentity()
+	classicId1, _ := age.GenerateX25519Identity()
+	classicId2, _ := age.GenerateX25519Identity()
+
+	policy := &SSS{
+		Threshold: 2,
+		Shares: []*SSS{
+			{Recipient: pqId.Recipient().String()},
+			{
+				Threshold: 1,
+				Shares: []*SSS{
+					{Recipient: classicId1.Recipient().String()},
+					{Recipient: classicId2.Recipient().String()},
+				},
+			},
+		},
+	}
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if !slices.Contains(labels, "postquantum") {
+		t.Error("outer 2-of-2 with 1 PQ leaf + 1 classic group: nonPQ(1) < threshold(2), should be PQ")
+	}
+}
+
+func TestWrapWithLabels_NestedNotPQ(t *testing.T) {
+	// Outer: 1-of-2
+	//   Share 1: PQ recipient
+	//   Share 2: classic recipient
+	// Outer: nonPQ=1 >= threshold=1 → not PQ
+
+	pqId, _ := age.GenerateHybridIdentity()
+	classicId, _ := age.GenerateX25519Identity()
+
+	policy := &SSS{
+		Threshold: 1,
+		Shares: []*SSS{
+			{Recipient: pqId.Recipient().String()},
+			{Recipient: classicId.Recipient().String()},
+		},
+	}
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if slices.Contains(labels, "postquantum") {
+		t.Error("1-of-2 with 1 classic share should not be PQ")
+	}
+}
+
+func TestWrapWithLabels_NestedPQInner(t *testing.T) {
+	// Outer: 1-of-2
+	//   Share 1: inner 2-of-2 all PQ (PQ group)
+	//   Share 2: inner 2-of-2 all PQ (PQ group)
+	// Outer: nonPQ=0 < threshold=1 → PQ
+
+	pq1, _ := age.GenerateHybridIdentity()
+	pq2, _ := age.GenerateHybridIdentity()
+	pq3, _ := age.GenerateHybridIdentity()
+	pq4, _ := age.GenerateHybridIdentity()
+
+	policy := &SSS{
+		Threshold: 1,
+		Shares: []*SSS{
+			{
+				Threshold: 2,
+				Shares: []*SSS{
+					{Recipient: pq1.Recipient().String()},
+					{Recipient: pq2.Recipient().String()},
+				},
+			},
+			{
+				Threshold: 2,
+				Shares: []*SSS{
+					{Recipient: pq3.Recipient().String()},
+					{Recipient: pq4.Recipient().String()},
+				},
+			},
+		},
+	}
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	_, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if !slices.Contains(labels, "postquantum") {
+		t.Error("1-of-2 where both inner groups are PQ should be PQ")
+	}
+}
+
+// Test that PQ recipients can actually be wrapped and unwrapped through SSS
+func TestPQRoundtrip(t *testing.T) {
+	pqId1, _ := age.GenerateHybridIdentity()
+	pqId2, _ := age.GenerateHybridIdentity()
+	pqId3, _ := age.GenerateHybridIdentity()
+
+	policy := &SSS{
+		Threshold: 2,
+		Shares: []*SSS{
+			{Recipient: pqId1.Recipient().String()},
+			{Recipient: pqId2.Recipient().String()},
+			{Recipient: pqId3.Recipient().String()},
+		},
+	}
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	stanzas, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	if !slices.Contains(labels, "postquantum") {
+		t.Error("all-PQ policy should have postquantum label")
+	}
+
+	// Unwrap with 2 of 3 identities
+	identity := &SSSIdentity{
+		Identities: []*SSSIdentityItem{
+			{IdentityStr: pqId1.String(), Identity: pqId1},
+			{IdentityStr: pqId2.String(), Identity: pqId2},
+		},
+	}
+
+	unwrapped, err := identity.Unwrap(stanzas)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !reflect.DeepEqual(fileKey, unwrapped) {
+		t.Error("round-trip file key mismatch")
+	}
+}
+
+// Test mixed PQ/classic round-trip
+func TestMixedPQClassicRoundtrip(t *testing.T) {
+	pqId, _ := age.GenerateHybridIdentity()
+	classicId, _ := age.GenerateX25519Identity()
+
+	policy := &SSS{
+		Threshold: 2,
+		Shares: []*SSS{
+			{Recipient: pqId.Recipient().String()},
+			{Recipient: classicId.Recipient().String()},
+		},
+	}
+
+	fileKey := make([]byte, 16)
+	cryptoRand.Read(fileKey)
+
+	stanzas, labels, err := policy.WrapWithLabels(fileKey)
+	if err != nil {
+		t.Fatalf("WrapWithLabels: %v", err)
+	}
+	// nonPQ=1 < threshold=2 → PQ
+	if !slices.Contains(labels, "postquantum") {
+		t.Error("2-of-2 with 1 PQ: should be PQ")
+	}
+
+	// Need both identities for 2-of-2
+	identity := &SSSIdentity{
+		Identities: []*SSSIdentityItem{
+			{IdentityStr: pqId.String(), Identity: pqId},
+			{IdentityStr: classicId.String(), Identity: classicId},
+		},
+	}
+
+	unwrapped, err := identity.Unwrap(stanzas)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !reflect.DeepEqual(fileKey, unwrapped) {
+		t.Error("round-trip file key mismatch")
+	}
 }

--- a/pkg/sss/stanza_test.go
+++ b/pkg/sss/stanza_test.go
@@ -19,7 +19,7 @@ func TestStanzaFormat(t *testing.T) {
 		t.Error("Failed decoding")
 	}
 
-	stanza, err := policy.wrap(wrapKey)
+	stanza, _, err := policy.wrap(wrapKey)
 	if err != nil {
 		t.Error("Failed creating stanza")
 	}


### PR DESCRIPTION
Let plugin identities decrypt any native stanza type, not just `x25519`. This makes sss work with olastor/age-plugin-fido2-hmac#50